### PR TITLE
implement HTML version of miniViz

### DIFF
--- a/css/paperbuzzviz.css
+++ b/css/paperbuzzviz.css
@@ -1,4 +1,4 @@
-.title {
+.paperbuzz-title {
     font-size: 1.5em;
     color: #789aa1;
     text-decoration: underline;
@@ -8,23 +8,19 @@
     font-size: 11px;
 }
 
-.axis line,
-.axis path {
+.paperbuzz-axis line,
+.paperbuzz-axis path {
     fill: none;
     stroke: black;
 	stroke-width: 1;
     shape-rendering: crispEdges;
 }
-.barsForTooltip {
-    fill: ffffff;
-    fill-opacity: 0;
-}
 
-.bar.main{
+.paperbuzz-bar.main{
 	fill: #789aa1;
 }
 
-.bar.alt{
+.paperbuzz-bar.alt{
 	fill: #304345;
 }
 
@@ -109,12 +105,7 @@
 	vertical-align: middle;
 }
 
-#built-with {
-    float: right;
-    font-size: .75em;
-}
-
-.paperbuzzTooltip {
+.paperbuzz-tooltip {
 	line-height: 1;
 	font: 10px sans-serif;
 	padding: 4px;
@@ -125,7 +116,7 @@
 }
 
 /* Creates a small triangle extender for the tooltip */
-.paperbuzzTooltip:after {
+.paperbuzz-tooltip:after {
 	box-sizing: border-box;
 	display: inline;
 	font-size: 10px;
@@ -138,14 +129,14 @@
 }
 
 /* Style northward tooltips differently */
-.paperbuzzTooltip.n:after {
+.paperbuzz-tooltip.n:after {
 	margin: -1px 0 0 0;
 	top: 100%;
 	left: 0;
 }
 
 /* Paperbuzz mini */
-.paperbuzz-mini-label {
+#paperbuzz-mini {
 	width: 250px;
     float: left;
     margin-top: .5em;
@@ -158,7 +149,30 @@
 	-webkit-border-radius: 5px; 
 	border-radius: 5px;
 	color: #28292b;	
-	
+	clear: both;
+}
+
+.paperbuzz-mini-total {
+	font-size: 3em;
+	color: #011a1f;
+	float: left;
+}
+
+.paperbuzz-mini-source {
+	color: #011a1f;
+	float: left;
+	padding: .4em;
+}
+.paperbuzz-mini-source > i{
+	padding-top: .4em;
+	padding-bottom: .em;
+	font-size: 1.15em;
+	vertical-align: middle;
+
+}
+
+.paperbuzz-mini-count {
+	margin-left: .2em;
 }
 
 /* Font icon css */
@@ -171,10 +185,10 @@
 	  url('../fonts/icomoon.svg?846v#icomoon') format('svg');
 	font-weight: normal;
 	font-style: normal;
-  }
+}
   
   
-  [class^="icon-"], [class*=" icon-"] {
+[class^="icon-"], [class*=" icon-"] {
 	/* use !important to prevent issues with browser extensions that change fonts */
 	font-family: 'icomoon' !important;
 	speak: none;
@@ -183,82 +197,53 @@
 	font-variant: normal;
 	text-transform: none;
 	line-height: 1;
-  
+
 	/* Better Font Rendering =========== */
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-  }
+}
   
-  .icon-crossref:before {
+.icon-crossref:before {
 	content: "\e90c";
-  }
-  .icon-datacite:before {
+}
+.icon-datacite:before {
 	content: "\e90b";
-  }
-  .icon-f1000:before {
+}
+.icon-f1000:before {
 	content: "\e90a";
-  }
-  .icon-hypothesis:before {
+}
+.icon-hypothesis:before {
 	content: "\e909";
-  }
-  .icon-cambia-lens:before {
+}
+.icon-cambia-lens:before {
 	content: "\e907";
-  }
-  .icon-stackexchange:before {
+}
+.icon-stackexchange:before {
 	content: "\e908";
 	color: #1e5397;
-  }
-  .icon-reddit-links:before {
+}
+.icon-reddit-links:before {
 	content: "\eac6";
-  }
-  .icon-web:before {
+}
+.icon-web:before {
 	content: "\e903";
-  }
-  .icon-wikipedia:before {
+}
+.icon-wikipedia:before {
 	content: "\e906";
-  }
-  .icon-newsfeed:before {
+}
+.icon-newsfeed:before {
 	content: "\e905";
-  }
-  .icon-facebook:before {
+}
+.icon-facebook:before {
 	content: "\e904";
-  }
-  .icon-reddit:before {
+}
+.icon-reddit:before {
 	content: "\e902";
-  }
-  .icon-wordpressdotcom:before {
+}
+.icon-wordpressdotcom:before {
 	content: "\e901";
-  }
-  .icon-twitter:before {
+}
+.icon-twitter:before {
 	content: "\e900";
-	}
-	
-	/* miniViz */
-	.miniViz-title {
-		font-size: .9em;
-    color: #011a1f;
-    text-decoration: underline;
-	}
-
-	.miniViz-title:hover {
-		cursor: pointer;
-	}
-
-	.miniViz-total {
-		font-size: 3em;
-		color: #011a1f;
-	}
-
-	.miniViz-text {
-		font-size: .75em;
-		color: #011a1f;
-	}
-
-	.miniViz-count {
-		font-size: 1.15em;
-		/*padding-bottom: 0.4em;
-		padding-top: 0.4em;
-		font-weight: bold;
-		vertical-align: middle;*/
-	}
+}
   

--- a/css/paperbuzzviz.css
+++ b/css/paperbuzzviz.css
@@ -88,15 +88,15 @@
 
 .paperbuzz-control.active {
 	text-decoration: none;
-	color: grey;
+	color: black;
 }
 
-.paperbuzz-control.disabled {
+/*.paperbuzz-control.disabled {
 	cursor: default;
 	text-decoration: none;
 	color: grey;
 }
-
+*/
 .paperbuzz-control:hover {
 	background-color: transparent;
 }

--- a/index.html
+++ b/index.html
@@ -16,6 +16,13 @@
 			width: 800px;
 			font-family: arial
 		}
+
+		#built-with {
+			clear: both;
+			float: right;
+			font-size: .75em;
+		}
+
 		</style>
 
 		<link rel="stylesheet" type="text/css" href="css/paperbuzzviz.css" />
@@ -40,16 +47,16 @@
 					graphheight: 150,
 					graphwidth:  300,
 					showTitle: true,
-					showMini: true,
+					showMini: false,
 					
 				}
 
 		var paperbuzzviz = undefined;
-		//var doi = '10.1080/23800127.2017.1283122';
-		//var doi = '10.15252/embj.201695429';
-		//var doi = '10.1016/j.quaint.2011.07.044';
-		//var doi = '10.4236/sn.2017.62007';
-		//var doi = '10.2190/EC.43.3.f'
+		// var doi = '10.1080/23800127.2017.1283122';
+		// var doi = '10.15252/embj.201695429';
+		// var doi = '10.1016/j.quaint.2011.07.044';
+		// var doi = '10.4236/sn.2017.62007';
+		// var doi = '10.2190/EC.43.3.f'
 		var doi = '10.1038/nature.2017.22163';
 		d3.json('https://api.paperbuzz.org/v0/doi/' + doi, function(data) {
 				options.paperbuzzStatsJson = data

--- a/paperbuzzviz.js
+++ b/paperbuzzviz.js
@@ -11,28 +11,23 @@ function PaperbuzzViz(options) {
     $ = options.jQuery || $;
 
     // Init basic options
-    var baseUrl = options.baseUrl;
-    var hasIcon = options.hasIcon;
-    var sources = [];
-    var eventcount = [];
-    var eventdate = [];
-    var eventsource =[];
     var minItems_ = options.minItemsToShowGraph;
     var showTitle = options.showTitle;
     var showMini = options.showMini;
+
     var formatNumber_ = d3.format(",d");
     var parseDate = d3.timeParse('%Y-%m-%d');
+
     var graphheight = options.graphheight;
     var graphwidth = options.graphwidth;
 
-    var published_date = options.published_date || false;
-
     var data = options.paperbuzzStatsJson;
+    var sources = data.altmetrics_sources;
 
+    var published_date = options.published_date || false;
         
     if (published_date) {
-    // accept the published date passed in, if there was one
-
+        // accept published date provided
     // Will choose pub date based on online pub, print pub, or issued. If no month or day defaults to 01
     } else if (data.metadata['published-online']) {
         published_date = data.metadata["published-online"]["date-parts"][0];
@@ -69,8 +64,7 @@ function PaperbuzzViz(options) {
 
     // to track if any metrics have been found
     var metricsFound_;
-
-    sources = data.altmetrics_sources
+    
 
      /**
      * Initialize the visualization.
@@ -90,7 +84,7 @@ function PaperbuzzViz(options) {
         vizDiv.append("br");
         
         if (sources.length > 0) {
-            if (showMini) {
+            if (showMini || !hasSVG_) {
                 addMiniViz(vizDiv, sources);
             } else {
                 // loop through sources
@@ -269,7 +263,7 @@ function PaperbuzzViz(options) {
                     $levelControlsDiv.append("a")
                         .attr("href", "javascript:void(0)")
                         .classed("paperbuzz-control", true)
-                        .classed("disabled", !showDaily)
+                        // .classed("disabled", !showDaily)
                         .classed("active", (level == 'day'))
                         .text("daily (first 30)")
                         .on("click", function() {
@@ -287,7 +281,7 @@ function PaperbuzzViz(options) {
                     $levelControlsDiv.append("a")
                         .attr("href", "javascript:void(0)")
                         .classed("paperbuzz-control", true)
-                        .classed("disabled", !showMonthly || !showYearly)
+                        // .classed("disabled", !showMonthly || !showYearly)
                         .classed("active", (level == 'month'))
                         .text("monthly")
                         .on("click", function() { if (showMonthly && !$(this).hasClass('active')) {
@@ -306,7 +300,7 @@ function PaperbuzzViz(options) {
                     $levelControlsDiv.append("a")
                         .attr("href", "javascript:void(0)")
                         .classed("paperbuzz-control", true)
-                        .classed("disabled", !showYearly || !showMonthly)
+                        // .classed("disabled", !showYearly || !showMonthly)
                         .classed("active", (level == 'year'))
                         .text("yearly")
                         .on("click", function() {

--- a/paperbuzzviz.js
+++ b/paperbuzzviz.js
@@ -83,7 +83,7 @@ function PaperbuzzViz(options) {
         if (showTitle) {
             vizDiv.append("a")
                 .attr('href', 'http://dx.doi.org/' + data.doi)
-                .attr("class", "title")
+                .attr("class", "paperbuzz-title")
                 .text(data.metadata.title);
         }
 
@@ -102,7 +102,7 @@ function PaperbuzzViz(options) {
            metricsFound_ = true;
         } else {
             vizDiv.append("p")
-                .attr("class", "muted")
+                .attr("class", "paperbuzz-muted")
                 .text("No metrics found.");
         }
     };
@@ -113,20 +113,21 @@ function PaperbuzzViz(options) {
                         .attr('id', 'paperbuzz-mini');
 
         miniDiv.append('span')
-            .attr('class', 'miniViz-total')
+            .attr('class', 'paperbuzz-mini-total')
 
         var total = 0;
         sources.forEach(function(source) {
-            miniDiv.append('span')
+            miniDiv.append('div')
+                .attr('class', 'paperbuzz-mini-source')
                 .append('i')
                 .attr('class', 'icon-' + source.source_id)
                 .append('span')
-                .attr('class', 'miniViz-count')
+                .attr('class', 'paperbuzz-mini-count')
                 .text(source.events_count);
             total += source.events_count
         });
 
-        miniDiv.selectAll('.miniViz-total')
+        miniDiv.selectAll('.paperbuzz-mini-total')
                 .text(total);
     }
 
@@ -447,15 +448,15 @@ function PaperbuzzViz(options) {
         viz.bars = viz.svg.append("g");
 
         viz.svg.append("g")
-            .attr("class", "x axis")
+            .attr("class", "x paperbuzz-axis")
             .attr("transform", "translate(0," + (viz.height - 1) + ")");
 
         viz.svg.append("g")
-            .attr("class", "y axis");
+            .attr("class", "y paperbuzz-axis");
 
         
         viz.tip = d3.tip()
-                .attr('class', 'paperbuzzTooltip')
+                .attr('class', 'paperbuzz-tooltip')
                 .html(function(d) { return 'Count: ' + d.count + "<br>" + 'Date: ' + d.date; });
         viz.tip.offset([-10, 0]); // make room for the little triangle
         viz.svg.call(viz.tip);
@@ -523,12 +524,12 @@ function PaperbuzzViz(options) {
         // TODO: these transitions could use a little work
         var barWidth = Math.max((viz.width/(timeInterval.range(pub_date, end_date).length + 1)) - 2, 1);
 
-        var bars = viz.bars.selectAll(".bar")
+        var bars = viz.bars.selectAll(".paperbuzz-bar")
             .data(level_data, function(d) { return getDate(level, d); });
 
         bars
             .enter().append("rect")
-            .attr("class", function(d) { return "bar " + viz.z((level == 'day' ? d3.timeWeek(getDate(level, d)) : d.year)); })
+            .attr("class", function(d) { return "paperbuzz-bar " + viz.z((level == 'day' ? d3.timeWeek(getDate(level, d)) : d.year)); })
             .attr("x", function(d) { return viz.x(getDate(level, d)) + 2; }) // padding of 2, 1 each 
             .attr("y", function(d) { return viz.y(d.count) } )
             .attr("width", barWidth)
@@ -541,7 +542,7 @@ function PaperbuzzViz(options) {
             .remove();
 
         viz.svg
-            .select(".x.axis")
+            .select(".x.paperbuzz-axis")
             .call((xAxis)
                 .tickFormat(d3.timeFormat(xFormat)))
             .selectAll("text")	
@@ -553,7 +554,7 @@ function PaperbuzzViz(options) {
 
         viz.svg
             .transition().duration(1000)
-            .select(".y.axis")
+            .select(".y.paperbuzz-axis")
             .call(yAxis);
     }
 

--- a/paperbuzzviz.js
+++ b/paperbuzzviz.js
@@ -529,7 +529,10 @@ function PaperbuzzViz(options) {
 
         bars
             .enter().append("rect")
-            .attr("class", function(d) { return "paperbuzz-bar " + viz.z((level == 'day' ? d3.timeWeek(getDate(level, d)) : d.year)); })
+            .attr("class", function(d) { 
+                var bartype = (level == 'day' ? d3.timeWeek(getDate(level, d)) : getDate(level, d).getFullYear());
+                return "paperbuzz-bar " + viz.z(bartype); 
+            })
             .attr("x", function(d) { return viz.x(getDate(level, d)) + 2; }) // padding of 2, 1 each 
             .attr("y", function(d) { return viz.y(d.count) } )
             .attr("width", barWidth)


### PR DESCRIPTION
I simplified the handling of published dates and the implementation for the miniViz. It now outputs straight HTML, instead of using SVG elements. Lots of styling left to do, but its functional. 